### PR TITLE
TST-27  add validation to comment form

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,3 +18,4 @@
 //= require carousel
 //= require lense
 //= require modal
+//= require problem

--- a/app/assets/javascripts/problem.js
+++ b/app/assets/javascripts/problem.js
@@ -1,0 +1,17 @@
+function enableDisablePostCommentBtn() {
+  var $commentInput = $('.comment__input');
+  $commentInput.on('input', function() {
+    var commentValue = $commentInput.val();
+    if($.trim(commentValue).length > 0) {
+      $('.comment__send-button').removeAttr('disabled');
+    } else {
+      $('.comment__send-button').attr('disabled', 'disabled');
+    }
+  });
+}
+
+$(document).on('turbolinks:load', function() {
+  if ($('.problems.show').length > 0 ) {
+    enableDisablePostCommentBtn();
+  }
+});

--- a/app/assets/stylesheets/problem-feed.scss
+++ b/app/assets/stylesheets/problem-feed.scss
@@ -144,15 +144,24 @@
 .comment__input {
   display: inline-block;
   padding: 10px 60px 10px 15px;
+
+  &:focus {
+    border-color: $logo-color;
+  }
 }
 
 .comment__send-button {
   display: inline-block;
   position: absolute;
   right: 10px;
-  top: 10px;
+  top: 8px;
   background: transparent;
   border: 0;
+  color: $logo-color;
+
+  &:disabled {
+    color: $light-grey;
+  }
 }
 
 .problems.new {

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :problem
   belongs_to :user
+
+  validates :description, presence: true
 end

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -39,6 +39,6 @@
       class: 'form-control comment__input' %>
     <%= hidden_field 'comment', 'problem_id', :value => @problem.id %>
     <%= hidden_field 'comment', 'user_id', :value => current_user.id %>
-    <%= submit_tag 'POST', class: 'comment__send-button' %>
+    <%= submit_tag 'POST', class: 'comment__send-button', disabled: true %>
   <% end %>
 </div>

--- a/spec/features/view_problem_spec.rb
+++ b/spec/features/view_problem_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'View Problem' do
+feature 'View Problem', js: true do
   background do
     @user = create(:user)
     @user2 = create(:user)
@@ -9,18 +9,32 @@ feature 'View Problem' do
     login_as(@user2, scope: :user)
   end
 
-  scenario 'views problem page with comment' do
+  scenario 'sees problem page with comment' do
     visit problem_path(@problem.id)
     expect(page).to have_content(@problem.name)
     expect(page).to have_content(@problem.thinking)
     expect(page).to have_content(@comment.description)
   end
 
-  scenario 'adds a comment to the problem' do
+  scenario 'disables post button by default' do
     visit problem_path(@problem.id)
-    value = 'hello world'
-    fill_in 'comment_description', with: value
-    click_on 'POST'
-    expect(page).to have_content("#{@user2.email}: #{value}")
+    expect(find('.comment__send-button')['disabled']).to eq true
+  end
+
+  context 'Adding a comment' do
+    scenario 'adds the comment successfully' do
+      visit problem_path(@problem.id)
+      value = 'hello world'
+      fill_in 'comment_description', with: value
+      expect(find('.comment__send-button')['disabled']).to eq false
+      click_on 'POST'
+      expect(page).to have_content("#{@user2.email}: #{value}")
+    end
+
+    scenario "cannot post the comment" do
+      visit problem_path(@problem.id)
+      fill_in 'comment_description', with: '          '
+      expect(find('.comment__send-button')['disabled']).to eq true
+    end
   end
 end


### PR DESCRIPTION
**Changed**
- added validation to comment form by using disable attribute to enable/disable post button.

**Preview**
- disable post btn by default
![screen shot 2560-02-20 at 9 24 15 pm](https://cloud.githubusercontent.com/assets/4001599/23128881/18432b54-f7b3-11e6-91a1-59da817b61c2.png)

- enable post btn when there are characters on comment field
![screen shot 2560-02-20 at 9 24 22 pm](https://cloud.githubusercontent.com/assets/4001599/23128882/1845c030-f7b3-11e6-9ac8-14cb11f22446.png)
